### PR TITLE
MANGO-332. Write unit tests for CreateChannelCommandHandler. Create separated folder. Each test case in the separated class where the seed data and implementation for ITestable interface.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiCommands/Communities/CreateChannelCommandHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/Communities/CreateChannelCommandHandler.cs
@@ -33,14 +33,6 @@ namespace MangoAPI.BusinessLogic.ApiCommands.Communities
         public async Task<Result<CreateCommunityResponse>> Handle(CreateChannelCommand request,
             CancellationToken cancellationToken)
         {
-            if (request.CommunityType is CommunityType.DirectChat or CommunityType.SecretChat)
-            {
-                const string errorMessage = ResponseMessageCodes.InvalidGroupType;
-                var description = ResponseMessageCodes.ErrorDictionary[errorMessage];
-
-                return _responseFactory.ConflictResponse(errorMessage, description);
-            }
-
             var ownerChatsCount =
                 await _postgresDbContext.UserChats
                     .Where(x => x.RoleId == (int)UserRole.Owner && x.UserId == request.UserId)

--- a/MangoAPI.BusinessLogic/ApiCommands/Communities/CreateChannelCommandValidator.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/Communities/CreateChannelCommandValidator.cs
@@ -10,11 +10,11 @@ namespace MangoAPI.BusinessLogic.ApiCommands.Communities
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .Length(1, 50);
-                
+
             RuleFor(x => x.ChannelDescription)
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
-                .Length(1, 300);
+                .Length(1, 100);
 
             RuleFor(x => x.CommunityType).IsInEnum();
         }

--- a/MangoAPI.Tests/ApiCommandsTests/CreateChannelCommandHandlerTests/CreateChannelShouldThrowCountExceed100.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/CreateChannelCommandHandlerTests/CreateChannelShouldThrowCountExceed100.cs
@@ -1,0 +1,88 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MangoAPI.BusinessLogic.ApiCommands.Communities;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.Domain.Constants;
+using MangoAPI.Domain.Entities;
+using MangoAPI.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MangoAPI.Tests.ApiCommandsTests.CreateChannelCommandHandlerTests
+{
+    public class CreateChannelShouldThrowCountExceed100 : ITestable<CreateChannelCommand, CreateCommunityResponse>
+    {
+        private readonly MangoDbFixture _mangoDbFixture = new();
+
+        [Fact]
+        public async Task CreateChannel_ShouldThrow_CountExceed100()
+        {
+            Seed();
+            const string expectedMessage = ResponseMessageCodes.MaximumOwnerChatsExceeded100;
+            var expectedDetails = ResponseMessageCodes.ErrorDictionary[expectedMessage];
+            var handler = CreateHandler();
+
+            async void Action(int _)
+            {
+                await handler.Handle(_createChannelCommand, CancellationToken.None);
+            }
+            
+            Enumerable.Range(1, 100).ToList().ForEach(Action);
+
+            var result = await handler.Handle(_createChannelCommand, CancellationToken.None);
+
+            result.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            result.Error.ErrorMessage.Should().Be(expectedMessage);
+            result.Error.ErrorDetails.Should().Be(expectedDetails);
+            result.Error.Success.Should().BeFalse();
+            result.Error.StatusCode.Should().Be(HttpStatusCode.Conflict);
+
+            result.Response.Should().BeNull();
+        }
+
+        public bool Seed()
+        {
+            _mangoDbFixture.Context.Users.Add(_user);
+
+            _mangoDbFixture.Context.SaveChanges();
+
+            _mangoDbFixture.Context.Entry(_user).State = EntityState.Detached;
+
+            return true;
+        }
+
+        public IRequestHandler<CreateChannelCommand, Result<CreateCommunityResponse>> CreateHandler()
+        {
+            var hubContext = MockedObjects.GetHubContext();
+            var responseFactory = new ResponseFactory<CreateCommunityResponse>();
+            var handler = new CreateChannelCommandHandler(_mangoDbFixture.Context, hubContext, responseFactory);
+            return handler;
+        }
+
+        private readonly UserEntity _user = new()
+        {
+            PhoneNumber = "48743615532",
+            DisplayName = "razumovsky r",
+            Bio = "11011 y.o Dotnet Developer from $\"{cityName}\"",
+            Id = SeedDataConstants.RazumovskyId,
+            UserName = "razumovsky_r",
+            Email = "kolosovp95@gmail.com",
+            NormalizedEmail = "KOLOSOVP94@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "razumovsky_picture.jpg"
+        };
+
+        private readonly CreateChannelCommand _createChannelCommand = new()
+        {
+            ChannelDescription = "My test channel",
+            ChannelTitle = "Test channel",
+            CommunityType = CommunityType.PublicChannel,
+            UserId = SeedDataConstants.RazumovskyId
+        };
+    }
+}

--- a/MangoAPI.Tests/ApiCommandsTests/CreateChannelCommandHandlerTests/CreateChannelTestSuccess.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/CreateChannelCommandHandlerTests/CreateChannelTestSuccess.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MangoAPI.BusinessLogic.ApiCommands.Communities;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.Domain.Constants;
+using MangoAPI.Domain.Entities;
+using MangoAPI.Domain.Enums;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MangoAPI.Tests.ApiCommandsTests.CreateChannelCommandHandlerTests
+{
+    public class CreateChannelTestSuccess : ITestable<CreateChannelCommand, CreateCommunityResponse>
+    {
+        private readonly MangoDbFixture _mangoDbFixture = new();
+
+        [Fact]
+        public async Task CreateChannelTest_Success()
+        {
+            Seed();
+            const string expectedMessage = ResponseMessageCodes.Success;
+            var handler = CreateHandler();
+
+            var result = await handler.Handle(_createChannelCommand, CancellationToken.None);
+
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            result.Response.Message.Should().Be(expectedMessage);
+            result.Response.Success.Should().BeTrue();
+            result.Response.ChatId.Should().NotBe(Guid.Empty);
+
+            result.Error.Should().BeNull();
+        }
+
+        public bool Seed()
+        {
+            _mangoDbFixture.Context.Users.Add(_user);
+
+            _mangoDbFixture.Context.SaveChanges();
+
+            _mangoDbFixture.Context.Entry(_user).State = EntityState.Detached;
+
+            return true;
+        }
+
+        public IRequestHandler<CreateChannelCommand, Result<CreateCommunityResponse>> CreateHandler()
+        {
+            var hubContext = MockedObjects.GetHubContext();
+            var responseFactory = new ResponseFactory<CreateCommunityResponse>();
+            var handler = new CreateChannelCommandHandler(_mangoDbFixture.Context, hubContext, responseFactory);
+            return handler;
+        }
+
+        private readonly UserEntity _user = new()
+        {
+            PhoneNumber = "48743615532",
+            DisplayName = "razumovsky r",
+            Bio = "11011 y.o Dotnet Developer from $\"{cityName}\"",
+            Id = SeedDataConstants.RazumovskyId,
+            UserName = "razumovsky_r",
+            Email = "kolosovp95@gmail.com",
+            NormalizedEmail = "KOLOSOVP94@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "razumovsky_picture.jpg"
+        };
+
+        private readonly CreateChannelCommand _createChannelCommand = new()
+        {
+            ChannelDescription = "My test channel",
+            ChannelTitle = "Test channel",
+            CommunityType = CommunityType.PublicChannel,
+            UserId = SeedDataConstants.RazumovskyId
+        };
+    }
+}


### PR DESCRIPTION
MANGO-332. Write unit tests for CreateChannelCommandHandler. Create separated folder. Each test case in the separated class where the seed data and implementation for ITestable interface.