### PR TITLE
MANGO-339. Write unit tests for CreateKeyExchangeRequestCommandHandler. Create separated folder. Each test case in the separated class where the seed data and implementation for ITestable interface.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/CreateKeyExchangeRequestCommandHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/CreateKeyExchangeRequestCommandHandler.cs
@@ -15,7 +15,8 @@ namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange
         private readonly MangoPostgresDbContext _postgresDbContext;
         private readonly ResponseFactory<CreateKeyExchangeResponse> _responseFactory;
 
-        public CreateKeyExchangeRequestCommandHandler(MangoPostgresDbContext postgresDbContext,
+        public CreateKeyExchangeRequestCommandHandler(
+            MangoPostgresDbContext postgresDbContext,
             ResponseFactory<CreateKeyExchangeResponse> responseFactory)
         {
             _postgresDbContext = postgresDbContext;

--- a/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeShouldThrowAlreadyExists.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeShouldThrowAlreadyExists.cs
@@ -1,0 +1,95 @@
+﻿using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.Domain.Constants;
+using MangoAPI.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MangoAPI.Tests.ApiCommandsTests.CreateKeyExchangeRequestCommandHandlerTests
+{
+    public class
+        CreateKeyExchangeShouldThrowAlreadyExists : ITestable<CreateKeyExchangeRequestCommand,
+            CreateKeyExchangeResponse>
+
+    {
+        private readonly MangoDbFixture _mangoDbFixture = new();
+
+        [Fact]
+        public async Task CreateKeyExchangeRequestCommandHandlerTest_ShouldThrow_AlreadyExists()
+        {
+            Seed();
+            const string expectedMessage = ResponseMessageCodes.KeyExchangeRequestAlreadyExists;
+            var expectedDetails = ResponseMessageCodes.ErrorDictionary[expectedMessage];
+            var handler = CreateHandler();
+            var command = new CreateKeyExchangeRequestCommand
+            {
+                PublicKey = "Public key",
+                RequestedUserId = SeedDataConstants.RazumovskyId,
+                UserId = SeedDataConstants.AmelitId
+            };
+
+            await handler.Handle(command, CancellationToken.None);
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            result.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            result.Response.Should().BeNull();
+            result.Error.ErrorMessage.Should().Be(expectedMessage);
+            result.Error.ErrorDetails.Should().Be(expectedDetails);
+            result.Error.Success.Should().BeFalse();
+            result.Error.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        }
+
+        public bool Seed()
+        {
+            _mangoDbFixture.Context.Users.Add(_sender);
+            _mangoDbFixture.Context.Users.Add(_receiver);
+
+            _mangoDbFixture.Context.SaveChanges();
+
+            _mangoDbFixture.Context.Entry(_sender).State = EntityState.Detached;
+            _mangoDbFixture.Context.Entry(_receiver).State = EntityState.Detached;
+
+            return true;
+        }
+
+        public IRequestHandler<CreateKeyExchangeRequestCommand, Result<CreateKeyExchangeResponse>> CreateHandler()
+        {
+            var context = _mangoDbFixture.Context;
+            var responseFactory = new ResponseFactory<CreateKeyExchangeResponse>();
+            var handler = new CreateKeyExchangeRequestCommandHandler(context, responseFactory);
+
+            return handler;
+        }
+
+        private readonly UserEntity _sender = new()
+        {
+            DisplayName = "Amelit",
+            Bio = "Дипломат",
+            Id = SeedDataConstants.AmelitId,
+            UserName = "TheMoonlightSonata",
+            Email = "amelit@gmail.com",
+            NormalizedEmail = "AMELIT@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "amelit_picture.jpg"
+        };
+
+        private readonly UserEntity _receiver = new()
+        {
+            DisplayName = "razumovsky r",
+            Bio = "11011 y.o Dotnet Developer from $\"{cityName}\"",
+            Id = SeedDataConstants.RazumovskyId,
+            UserName = "razumovsky_r",
+            Email = "kolosovp95@gmail.com",
+            NormalizedEmail = "KOLOSOVP94@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "razumovsky_picture.jpg"
+        };
+    }
+}

--- a/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeShouldThrowUserNotFound.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeShouldThrowUserNotFound.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.Domain.Constants;
+using MangoAPI.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MangoAPI.Tests.ApiCommandsTests.CreateKeyExchangeRequestCommandHandlerTests
+{
+    public class CreateKeyExchangeShouldThrowUserNotFound : ITestable<CreateKeyExchangeRequestCommand,
+        CreateKeyExchangeResponse>
+    {
+        private readonly MangoDbFixture _mangoDbFixture = new();
+
+        [Fact]
+        public async Task CreateKeyExchangeRequestCommandHandlerTest_ShouldThrow_UserNotFound()
+        {
+            Seed();
+            const string expectedMessage = ResponseMessageCodes.UserNotFound;
+            var expectedDetails = ResponseMessageCodes.ErrorDictionary[expectedMessage];
+            var handler = CreateHandler();
+            var command = new CreateKeyExchangeRequestCommand
+            {
+                PublicKey = "Public key",
+                RequestedUserId = Guid.NewGuid(),
+                UserId = SeedDataConstants.AmelitId
+            };
+            
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            result.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            result.Response.Should().BeNull();
+            result.Error.ErrorMessage.Should().Be(expectedMessage);
+            result.Error.ErrorDetails.Should().Be(expectedDetails);
+            result.Error.Success.Should().BeFalse();
+            result.Error.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        }
+        
+        public bool Seed()
+        {
+            _mangoDbFixture.Context.Users.Add(_sender);
+
+            _mangoDbFixture.Context.SaveChanges();
+
+            _mangoDbFixture.Context.Entry(_sender).State = EntityState.Detached;
+
+            return true;
+        }
+
+        public IRequestHandler<CreateKeyExchangeRequestCommand, Result<CreateKeyExchangeResponse>> CreateHandler()
+        {
+            var context = _mangoDbFixture.Context;
+            var responseFactory = new ResponseFactory<CreateKeyExchangeResponse>();
+            var handler = new CreateKeyExchangeRequestCommandHandler(context, responseFactory);
+
+            return handler;
+        }
+        
+        private readonly UserEntity _sender = new()
+        {
+            DisplayName = "Amelit",
+            Bio = "Дипломат",
+            Id = SeedDataConstants.AmelitId,
+            UserName = "TheMoonlightSonata",
+            Email = "amelit@gmail.com",
+            NormalizedEmail = "AMELIT@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "amelit_picture.jpg"
+        };
+    }
+}

--- a/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeSuccess.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/CreateKeyExchangeRequestCommandHandlerTests/CreateKeyExchangeSuccess.cs
@@ -1,0 +1,90 @@
+﻿using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.Domain.Constants;
+using MangoAPI.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MangoAPI.Tests.ApiCommandsTests.CreateKeyExchangeRequestCommandHandlerTests
+{
+    public class CreateKeyExchangeSuccess : ITestable<CreateKeyExchangeRequestCommand,
+        CreateKeyExchangeResponse>
+    {
+        private readonly MangoDbFixture _mangoDbFixture = new();
+
+        [Fact]
+        public async Task CreateKeyExchangeRequestCommandHandlerTest_Success()
+        {
+            Seed();
+            const string expectedMessage = ResponseMessageCodes.Success;
+            var handler = CreateHandler();
+            var command = new CreateKeyExchangeRequestCommand
+            {
+                PublicKey = "Public key",
+                RequestedUserId = SeedDataConstants.RazumovskyId,
+                UserId = SeedDataConstants.AmelitId
+            };
+
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+            result.Error.Should().BeNull();
+            result.Response.Message.Should().Be(expectedMessage);
+            result.Response.RequestId.Should().NotBeEmpty();
+            result.Response.Success.Should().BeTrue();
+        }
+
+        public bool Seed()
+        {
+            _mangoDbFixture.Context.Users.Add(_sender);
+            _mangoDbFixture.Context.Users.Add(_receiver);
+
+            _mangoDbFixture.Context.SaveChanges();
+
+            _mangoDbFixture.Context.Entry(_sender).State = EntityState.Detached;
+            _mangoDbFixture.Context.Entry(_receiver).State = EntityState.Detached;
+
+            return true;
+        }
+
+        public IRequestHandler<CreateKeyExchangeRequestCommand, Result<CreateKeyExchangeResponse>> CreateHandler()
+        {
+            var context = _mangoDbFixture.Context;
+            var responseFactory = new ResponseFactory<CreateKeyExchangeResponse>();
+            var handler = new CreateKeyExchangeRequestCommandHandler(context, responseFactory);
+
+            return handler;
+        }
+
+        private readonly UserEntity _sender = new()
+        {
+            DisplayName = "Amelit",
+            Bio = "Дипломат",
+            Id = SeedDataConstants.AmelitId,
+            UserName = "TheMoonlightSonata",
+            Email = "amelit@gmail.com",
+            NormalizedEmail = "AMELIT@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "amelit_picture.jpg"
+        };
+
+        private readonly UserEntity _receiver = new()
+        {
+            DisplayName = "razumovsky r",
+            Bio = "11011 y.o Dotnet Developer from $\"{cityName}\"",
+            Id = SeedDataConstants.RazumovskyId,
+            UserName = "razumovsky_r",
+            Email = "kolosovp95@gmail.com",
+            NormalizedEmail = "KOLOSOVP94@GMAIL.COM",
+            EmailConfirmed = true,
+            PhoneNumberConfirmed = true,
+            Image = "razumovsky_picture.jpg"
+        };
+    }
+}


### PR DESCRIPTION
MANGO-339. Write unit tests for CreateKeyExchangeRequestCommandHandler. Create separated folder. Each test case in the separated class where the seed data and implementation for ITestable interface.