### PR TITLE
MANGO-392. Implement CLI command: openssl-generate-dh-parameters, creates a DH parameters using openssl.

### DIFF
--- a/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
+++ b/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using MangoAPI.DiffieHellmanConsole.CngHandlers;
 using MangoAPI.DiffieHellmanConsole.Handlers;
+using MangoAPI.DiffieHellmanConsole.OpenSslHandlers;
 using MangoAPI.DiffieHellmanConsole.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,7 +9,7 @@ namespace MangoAPI.DiffieHellmanConsole.Extensions;
 
 public static class InjectionExtensions
 {
-    public static IServiceCollection AddCngServicesAndHandlers(this IServiceCollection collection)
+    public static IServiceCollection AddServices(this IServiceCollection collection)
     {
         collection.AddSingleton<HttpClient>();
         collection.AddSingleton<EcdhService>();
@@ -18,13 +19,33 @@ public static class InjectionExtensions
         collection.AddSingleton<TokensService>();
 
         collection.AddSingleton<LoginHandler>();
-        collection.AddSingleton<PrintKeyExchangeListHandler>();
-        collection.AddSingleton<PrintPublicKeysHandler>();
         collection.AddSingleton<RefreshTokenHandler>();
 
+        return collection;
+    }
+    
+    public static IServiceCollection AddAuthHandlers(this IServiceCollection collection)
+    {
+        collection.AddSingleton<LoginHandler>();
+        collection.AddSingleton<RefreshTokenHandler>();
+
+        return collection;
+    }
+    
+    public static IServiceCollection AddCngHandlers(this IServiceCollection collection)
+    {
+        collection.AddSingleton<CngPrintKeyExchangeListHandler>();
+        collection.AddSingleton<CngPrintPublicKeysHandler>();
         collection.AddSingleton<CngConfirmKeyExchangeRequestHandler>();
         collection.AddSingleton<CngCreateCommonSecretHandler>();
         collection.AddSingleton<CngRequestKeyExchangeHandler>();
+
+        return collection;
+    }
+    
+    public static IServiceCollection AddOpenSslHandlers(this IServiceCollection collection)
+    {
+        collection.AddSingleton<OpenSslCreateDhParametersHandler>();
 
         return collection;
     }

--- a/MangoAPI.DiffieHellmanConsole/Handlers/CngPrintKeyExchangeListHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/Handlers/CngPrintKeyExchangeListHandler.cs
@@ -4,11 +4,11 @@ using MangoAPI.DiffieHellmanConsole.Services;
 
 namespace MangoAPI.DiffieHellmanConsole.Handlers;
 
-public class PrintKeyExchangeListHandler
+public class CngPrintKeyExchangeListHandler
 {
     private readonly KeyExchangeService _keyExchangeService;
 
-    public PrintKeyExchangeListHandler(KeyExchangeService keyExchangeService)
+    public CngPrintKeyExchangeListHandler(KeyExchangeService keyExchangeService)
     {
         _keyExchangeService = keyExchangeService;
     }

--- a/MangoAPI.DiffieHellmanConsole/Handlers/CngPrintPublicKeysHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/Handlers/CngPrintPublicKeysHandler.cs
@@ -4,11 +4,11 @@ using MangoAPI.DiffieHellmanConsole.Services;
 
 namespace MangoAPI.DiffieHellmanConsole.Handlers;
 
-public class PrintPublicKeysHandler
+public class CngPrintPublicKeysHandler
 {
     private readonly PublicKeysService _publicKeysService;
 
-    public PrintPublicKeysHandler(PublicKeysService publicKeysService)
+    public CngPrintPublicKeysHandler(PublicKeysService publicKeysService)
     {
         _publicKeysService = publicKeysService;
     }

--- a/MangoAPI.DiffieHellmanConsole/MangoAPI.DiffieHellmanConsole.csproj
+++ b/MangoAPI.DiffieHellmanConsole/MangoAPI.DiffieHellmanConsole.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="CliWrap" Version="3.4.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateDhParametersHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateDhParametersHandler.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using CliWrap;
+
+namespace MangoAPI.DiffieHellmanConsole.OpenSslHandlers;
+
+public class OpenSslCreateDhParametersHandler
+{
+    public async Task<bool> CreateDhParametersAsync()
+    {
+        try
+        {
+            Console.WriteLine("Generating DH parameters... Please wait.");
+
+            var cmd = Cli.Wrap("openssl").WithArguments(
+                new[] {"genpkey", "-genparam", "-algorithm", "DH", "-out", "dhp.pem"});
+
+            await cmd.ExecuteAsync();
+
+            Console.WriteLine("DH parameters has been generated successfully.");
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return false;
+        }
+    }
+}

--- a/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateDhParametersHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateDhParametersHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using CliWrap;
 
@@ -12,8 +13,10 @@ public class OpenSslCreateDhParametersHandler
         {
             Console.WriteLine("Generating DH parameters... Please wait.");
 
+            var path = Path.Combine(AppContext.BaseDirectory, "dhp.pem");
+
             var cmd = Cli.Wrap("openssl").WithArguments(
-                new[] {"genpkey", "-genparam", "-algorithm", "DH", "-out", "dhp.pem"});
+                new[] {"genpkey", "-genparam", "-algorithm", "DH", "-out", path});
 
             await cmd.ExecuteAsync();
 

--- a/MangoAPI.DiffieHellmanConsole/Program.cs
+++ b/MangoAPI.DiffieHellmanConsole/Program.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using MangoAPI.DiffieHellmanConsole.CngHandlers;
 using MangoAPI.DiffieHellmanConsole.Extensions;
 using MangoAPI.DiffieHellmanConsole.Handlers;
+using MangoAPI.DiffieHellmanConsole.OpenSslHandlers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MangoAPI.DiffieHellmanConsole;
@@ -18,7 +19,10 @@ public static class Program
         }
 
         var serviceProvider = new ServiceCollection()
-            .AddCngServicesAndHandlers()
+            .AddAuthHandlers()
+            .AddServices()
+            .AddCngHandlers()
+            .AddOpenSslHandlers()
             .BuildServiceProvider();
 
         var method = args[0];
@@ -54,9 +58,9 @@ public static class Program
             }
             case "cng-key-exchange-requests":
             {
-                var handler = serviceProvider.GetService<PrintKeyExchangeListHandler>() ??
+                var handler = serviceProvider.GetService<CngPrintKeyExchangeListHandler>() ??
                               throw new ArgumentException(
-                                  $"Handler is null. Register it in dependency injection. {nameof(PrintKeyExchangeListHandler)}");
+                                  $"Handler is null. Register it in dependency injection. {nameof(CngPrintKeyExchangeListHandler)}");
 
                 await handler.PrintKeyExchangesListAsync();
                 break;
@@ -72,9 +76,9 @@ public static class Program
             }
             case "cng-print-public-keys":
             {
-                var handler = serviceProvider.GetService<PrintPublicKeysHandler>() ??
+                var handler = serviceProvider.GetService<CngPrintPublicKeysHandler>() ??
                               throw new ArgumentException(
-                                  $"Handler is null. Register it in dependency injection. {nameof(PrintPublicKeysHandler)}");
+                                  $"Handler is null. Register it in dependency injection. {nameof(CngPrintPublicKeysHandler)}");
 
                 await handler.PrintPublicKeysAsync();
                 break;
@@ -86,6 +90,15 @@ public static class Program
                                   $"Handler is null. Register it in dependency injection. {nameof(CngCreateCommonSecretHandler)}");
 
                 await handler.CreateCommonSecret(args);
+                break;
+            }
+            case "openssl-generate-dh-parameters":
+            {
+                var handler = serviceProvider.GetService<OpenSslCreateDhParametersHandler>() ??
+                              throw new ArgumentException(
+                                  $"Handler is null. Register it in dependency injection. {nameof(OpenSslCreateDhParametersHandler)}");
+
+                await handler.CreateDhParametersAsync();
                 break;
             }
             default:

--- a/MangoAPI.Tests/ApiCommandsTests/UpdateProfilePictureCommandHandlerTests/UpdateProfilePictureTestShouldThrowUploadedDocumentsLimitReached10.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/UpdateProfilePictureCommandHandlerTests/UpdateProfilePictureTestShouldThrowUploadedDocumentsLimitReached10.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace MangoAPI.Tests.ApiCommandsTests.UpdatePictureCommandHandlerTests;
+namespace MangoAPI.Tests.ApiCommandsTests.UpdateProfilePictureCommandHandlerTests;
 
 public class UpdateProfilePictureTestShouldThrowUploadedDocumentsLimitReached10
     : ITestable<UpdateProfilePictureCommand, UpdateProfilePictureResponse>

--- a/MangoAPI.Tests/ApiCommandsTests/UpdateProfilePictureCommandHandlerTests/UpdateProfilePictureTestSuccess.cs
+++ b/MangoAPI.Tests/ApiCommandsTests/UpdateProfilePictureCommandHandlerTests/UpdateProfilePictureTestSuccess.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Http.Internal;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
 
-namespace MangoAPI.Tests.ApiCommandsTests.UpdatePictureCommandHandlerTests;
+namespace MangoAPI.Tests.ApiCommandsTests.UpdateProfilePictureCommandHandlerTests;
 
 public class UpdateProfilePictureTestSuccess 
     : ITestable<UpdateProfilePictureCommand, UpdateProfilePictureResponse>


### PR DESCRIPTION
Implement CLI command: openssl-generate-dh-parameters, creates a DH parameters using openssl