### PR TITLE
MANGO-399. Implement GET: api/key-exchange/openssl-key-exchange-requests, returns a list of key exchange requests.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsQuery.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsQuery.cs
@@ -1,0 +1,10 @@
+using System;
+using MangoAPI.BusinessLogic.Responses;
+using MediatR;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public record GetOpenSslKeyExchangeRequestsQuery : IRequest<Result<GetOpenSslKeyExchangeRequestsResponse>>
+{
+    public Guid UserId { get; init; }
+}

--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsQueryHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsQueryHandler.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MangoAPI.BusinessLogic.Models;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.DataAccess.Database;
+using MangoAPI.Domain.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public class GetOpenSslKeyExchangeRequestsQueryHandler : IRequestHandler<GetOpenSslKeyExchangeRequestsQuery,
+    Result<GetOpenSslKeyExchangeRequestsResponse>>
+{
+    private readonly MangoPostgresDbContext _mangoPostgresDbContext;
+    private readonly ResponseFactory<GetOpenSslKeyExchangeRequestsResponse> _responseFactory;
+
+    public GetOpenSslKeyExchangeRequestsQueryHandler(
+        MangoPostgresDbContext mangoPostgresDbContext,
+        ResponseFactory<GetOpenSslKeyExchangeRequestsResponse> responseFactory)
+    {
+        _mangoPostgresDbContext = mangoPostgresDbContext;
+        _responseFactory = responseFactory;
+    }
+
+    public async Task<Result<GetOpenSslKeyExchangeRequestsResponse>> Handle(GetOpenSslKeyExchangeRequestsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var requests = await _mangoPostgresDbContext.OpenSslKeyExchangeRequests
+            .Where(x => x.SenderId == request.UserId || x.ReceiverId == request.UserId)
+            .Select(x => new OpenSslKeyExchangeRequest
+            {
+                Actor = x.SenderId == request.UserId ? Actor.Sender : Actor.Receiver,
+                IsConfirmed = x.IsConfirmed,
+                ReceiverId = x.ReceiverId,
+                RequestId = x.Id,
+                SenderId = x.SenderId
+            }).ToListAsync(cancellationToken);
+
+        var response = new GetOpenSslKeyExchangeRequestsResponse
+        {
+            Message = ResponseMessageCodes.Success,
+            OpenSslKeyExchangeRequests = requests,
+            Success = true,
+        };
+
+        return _responseFactory.SuccessResponse(response);
+    }
+}

--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsResponse.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/GetOpenSslKeyExchangeRequestsResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using MangoAPI.BusinessLogic.Models;
+using MangoAPI.BusinessLogic.Responses;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public record GetOpenSslKeyExchangeRequestsResponse : ResponseBase
+{
+    public List<OpenSslKeyExchangeRequest> OpenSslKeyExchangeRequests { get; init; }
+}

--- a/MangoAPI.BusinessLogic/Models/OpenSslKeyExchangeRequest.cs
+++ b/MangoAPI.BusinessLogic/Models/OpenSslKeyExchangeRequest.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace MangoAPI.BusinessLogic.Models;
+
+public record OpenSslKeyExchangeRequest
+{
+    public Guid RequestId { get; init; }
+    public Guid SenderId { get; init; }
+    public Guid ReceiverId { get; init; }
+    public bool IsConfirmed { get; init; }
+    public Actor Actor { get; init; }
+}
+
+public enum Actor
+{
+    Sender = 1,
+    Receiver = 2,
+}

--- a/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
+++ b/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
@@ -71,6 +71,15 @@ public class KeyExchangeController : ApiControllerBase, IKeyExchangeController
         return await RequestAsync(command, cancellationToken);
     }
 
+    [HttpGet("openssl-key-exchange-requests")]
+    public async Task<IActionResult> OpenSslGetKeyExchangeRequests(CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.User.GetUserId();
+        var request = new GetOpenSslKeyExchangeRequestsQuery {UserId = userId};
+
+        return await RequestAsync(request, cancellationToken);
+    }
+
     /// <summary>
     /// Returns all user's Diffie-Hellman key exchange requests.
     /// </summary>

--- a/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
+++ b/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
@@ -15,6 +15,8 @@ public interface IKeyExchangeController
 
     public Task<IActionResult> OpenSslCreateKeyExchangeRequest(Guid userId, IFormFile senderPublicKey,
         CancellationToken cancellationToken);
+    
+    public Task<IActionResult> OpenSslGetKeyExchangeRequests(CancellationToken cancellationToken);
 
     public Task<IActionResult> CngGetKeyExchangeRequests(CancellationToken cancellationToken);
 


### PR DESCRIPTION
MANGO-399. Implement GET: api/key-exchange/openssl-key-exchange-requests, returns a list of key exchange requests.