### PR TITLE
MANGO-400. Implement PUT: api/key-exchange/openssl-key-exchange-requests/{requestId}, confirms or declines key exchange request.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommand.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommand.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using MangoAPI.BusinessLogic.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+
+public record OpenSslConfirmKeyExchangeCommand : IRequest<Result<ResponseBase>>
+{
+    public Guid RequestId { get; init; }
+    public Guid UserId { get; init; }
+    public bool Confirmed { get; init; }
+    public IFormFile ReceiverPublicKey { get; init; }
+}

--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandHandler.cs
@@ -1,0 +1,60 @@
+﻿using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.DataAccess.Database;
+using MangoAPI.Domain.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+
+public class
+    OpenSslConfirmKeyExchangeCommandHandler : IRequestHandler<OpenSslConfirmKeyExchangeCommand, Result<ResponseBase>>
+{
+    private readonly MangoPostgresDbContext _mangoPostgresDbContext;
+    private readonly ResponseFactory<ResponseBase> _responseFactory;
+
+    public OpenSslConfirmKeyExchangeCommandHandler(MangoPostgresDbContext mangoPostgresDbContext,
+        ResponseFactory<ResponseBase> responseFactory)
+    {
+        _mangoPostgresDbContext = mangoPostgresDbContext;
+        _responseFactory = responseFactory;
+    }
+
+    public async Task<Result<ResponseBase>> Handle(OpenSslConfirmKeyExchangeCommand request,
+        CancellationToken cancellationToken)
+    {
+        var keyExchangeRequest = await _mangoPostgresDbContext.OpenSslKeyExchangeRequests
+            .FirstOrDefaultAsync(
+                predicate: x => x.Id == request.RequestId,
+                cancellationToken: cancellationToken);
+
+        if (keyExchangeRequest == null || keyExchangeRequest.ReceiverId != request.UserId)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeRequestNotFound;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        if (!request.Confirmed)
+        {
+            keyExchangeRequest.IsConfirmed = false;
+
+            await _mangoPostgresDbContext.SaveChangesAsync(cancellationToken);
+            return _responseFactory.SuccessResponse(ResponseBase.SuccessResponse);
+        }
+
+        await using var target = new MemoryStream();
+        await request.ReceiverPublicKey.CopyToAsync(target, cancellationToken);
+
+        var bytes = target.ToArray();
+
+        keyExchangeRequest.ReceiverPublicKey = bytes;
+        keyExchangeRequest.IsConfirmed = true;
+
+        await _mangoPostgresDbContext.SaveChangesAsync(cancellationToken);
+        return _responseFactory.SuccessResponse(ResponseBase.SuccessResponse);
+    }
+}

--- a/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
+++ b/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
@@ -80,6 +80,26 @@ public class KeyExchangeController : ApiControllerBase, IKeyExchangeController
         return await RequestAsync(request, cancellationToken);
     }
 
+    [HttpPut("openssl-key-exchange-requests/{requestId:guid}")]
+    public async Task<IActionResult> OpenSslConfirmKeyExchangeRequest(
+        [FromRoute] Guid requestId,
+        [FromQuery] bool confirmed,
+        [FromForm] IFormFile receiverPublicKey,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.User.GetUserId();
+
+        var command = new OpenSslConfirmKeyExchangeCommand
+        {
+            RequestId = requestId,
+            UserId = userId,
+            Confirmed = confirmed,
+            ReceiverPublicKey = receiverPublicKey
+        };
+
+        return await RequestAsync(command, cancellationToken);
+    }
+
     /// <summary>
     /// Returns all user's Diffie-Hellman key exchange requests.
     /// </summary>

--- a/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
+++ b/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
@@ -15,8 +15,14 @@ public interface IKeyExchangeController
 
     public Task<IActionResult> OpenSslCreateKeyExchangeRequest(Guid userId, IFormFile senderPublicKey,
         CancellationToken cancellationToken);
-    
+
     public Task<IActionResult> OpenSslGetKeyExchangeRequests(CancellationToken cancellationToken);
+
+    public Task<IActionResult> OpenSslConfirmKeyExchangeRequest(
+        Guid requestId,
+        bool confirmed,
+        IFormFile receiverPublicKey,
+        CancellationToken cancellationToken);
 
     public Task<IActionResult> CngGetKeyExchangeRequests(CancellationToken cancellationToken);
 


### PR DESCRIPTION
Implement PUT: api/key-exchange/openssl-key-exchange-requests/{requestId}, confirms or declines key exchange request.