### PR TITLE
MANGO-401. Implement GET: api/key-exchange/openssl-key-exchange-requests/public-key/{requestId}, downloads a public key of the partner on key exchange request.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/CreateDiffieHellmanParameterRequest.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/CreateDiffieHellmanParameterRequest.cs
@@ -1,6 +1,0 @@
-﻿namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
-
-public record CreateDiffieHellmanParameterRequest
-{
-    public byte[] DiffieHellmanParameter { get; init; }
-}

--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyQuery.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyQuery.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using MangoAPI.BusinessLogic.Responses;
+using MediatR;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public record OpenSslDownloadPartnerPublicKeyQuery : IRequest<Result<OpenSslDownloadPartnerPublicKeyResponse>>
+{
+    public Guid UserId { get; init; }
+    public Guid RequestId { get; init; }
+}

--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyQueryHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyQueryHandler.cs
@@ -1,0 +1,88 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.DataAccess.Database;
+using MangoAPI.Domain.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public class OpenSslDownloadPartnerPublicKeyQueryHandler : IRequestHandler<OpenSslDownloadPartnerPublicKeyQuery,
+    Result<OpenSslDownloadPartnerPublicKeyResponse>>
+{
+    private readonly MangoPostgresDbContext _mangoPostgresDbContext;
+    private readonly ResponseFactory<OpenSslDownloadPartnerPublicKeyResponse> _responseFactory;
+
+    public OpenSslDownloadPartnerPublicKeyQueryHandler(MangoPostgresDbContext mangoPostgresDbContext,
+        ResponseFactory<OpenSslDownloadPartnerPublicKeyResponse> responseFactory)
+    {
+        _mangoPostgresDbContext = mangoPostgresDbContext;
+        _responseFactory = responseFactory;
+    }
+
+    public async Task<Result<OpenSslDownloadPartnerPublicKeyResponse>> Handle(
+        OpenSslDownloadPartnerPublicKeyQuery request, CancellationToken cancellationToken)
+    {
+        var keyExchangeRequest = await _mangoPostgresDbContext.OpenSslKeyExchangeRequests
+            .FirstOrDefaultAsync(
+                predicate: x => x.Id == request.RequestId,
+                cancellationToken: cancellationToken);
+
+        if (keyExchangeRequest == null)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeRequestNotFound;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        if (!keyExchangeRequest.IsConfirmed)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeIsNotConfirmed;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        var belongsToUser = keyExchangeRequest.SenderId == request.UserId ||
+                            keyExchangeRequest.ReceiverId == request.UserId;
+
+        if (!belongsToUser)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeDoesNotBelongToUser;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        var isSender = keyExchangeRequest.SenderId == request.UserId;
+
+        var partnerId = isSender
+            ? keyExchangeRequest.ReceiverId
+            : keyExchangeRequest.SenderId;
+
+        if (isSender)
+        {
+            var receiverResponse = new OpenSslDownloadPartnerPublicKeyResponse
+            {
+                Message = ResponseMessageCodes.Success,
+                PartnerId = partnerId,
+                PublicKey = keyExchangeRequest.ReceiverPublicKey,
+                Success = true,
+            };
+
+            return _responseFactory.SuccessResponse(receiverResponse);
+        }
+
+        var senderResponse = new OpenSslDownloadPartnerPublicKeyResponse
+        {
+            Message = ResponseMessageCodes.Success,
+            PartnerId = partnerId,
+            PublicKey = keyExchangeRequest.SenderPublicKey,
+            Success = true,
+        };
+
+        return _responseFactory.SuccessResponse(senderResponse);
+    }
+}

--- a/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyResponse.cs
+++ b/MangoAPI.BusinessLogic/ApiQueries/KeyExchange/OpenSslDownloadPartnerPublicKeyResponse.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using MangoAPI.BusinessLogic.Responses;
+
+namespace MangoAPI.BusinessLogic.ApiQueries.KeyExchange;
+
+public record OpenSslDownloadPartnerPublicKeyResponse : ResponseBase
+{
+    public byte[] PublicKey { get; init; }
+    public Guid PartnerId { get; init; }
+}

--- a/MangoAPI.Domain/Constants/ResponseMessageCodes.cs
+++ b/MangoAPI.Domain/Constants/ResponseMessageCodes.cs
@@ -49,6 +49,8 @@ public static class ResponseMessageCodes
         {MessageNotFound, "Message doesn't found in the system"},
         {DhParameterNotFound, "Diffie-Hellman parameter is not initialized. Please initialize first."},
         {TokensNotFound, "Tokens not found. Please login to the system first."},
+        {KeyExchangeIsNotConfirmed, "Key exchange is not confirmed yet, please wait for response."},
+        {KeyExchangeDoesNotBelongToUser, "Key exchange does not belong to you."}
     };
 
     public const string Success = "SUCCESS";
@@ -82,4 +84,6 @@ public static class ResponseMessageCodes
     public const string MessageNotFound = "MESSAGE_NOT_FOUND";
     public const string DhParameterNotFound = "DH_PARAMETER_NOT_FOUND";
     public const string TokensNotFound = "TOKENS_NOT_FOUND";
+    public const string KeyExchangeIsNotConfirmed = "KEY_EXCHANGE_IS_NOT_CONFIRMED";
+    public const string KeyExchangeDoesNotBelongToUser = "KEY_EXCHANGE_DOES_NOT_BELONG_TO_USER";
 }

--- a/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
+++ b/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
@@ -100,6 +100,27 @@ public class KeyExchangeController : ApiControllerBase, IKeyExchangeController
         return await RequestAsync(command, cancellationToken);
     }
 
+    [HttpGet("openssl-key-exchange-requests/public-keys/{requestId:guid}")]
+    public async Task<IActionResult> OpenSslDownloadPartnerPublicKey(Guid requestId,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.User.GetUserId();
+
+        var query = new OpenSslDownloadPartnerPublicKeyQuery
+        {
+            UserId = userId,
+            RequestId = requestId,
+        };
+
+        var result = await Mediator.Send(query, cancellationToken);
+
+        var fileName = $"PUBLIC_KEY_{result.Response.PartnerId}";
+
+        var file = File(result.Response.PublicKey, contentType: "text/plain", fileName);
+
+        return file;
+    }
+
     /// <summary>
     /// Returns all user's Diffie-Hellman key exchange requests.
     /// </summary>

--- a/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
+++ b/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
@@ -24,6 +24,9 @@ public interface IKeyExchangeController
         IFormFile receiverPublicKey,
         CancellationToken cancellationToken);
 
+    public Task<IActionResult> OpenSslDownloadPartnerPublicKey(Guid requestId,
+        CancellationToken cancellationToken);
+
     public Task<IActionResult> CngGetKeyExchangeRequests(CancellationToken cancellationToken);
 
     public Task<IActionResult> CngCreteKeyExchangeRequest(CreateKeyExchangeRequest request,

--- a/MangoAPI.Presentation/Profiles/PresentationProfile.cs
+++ b/MangoAPI.Presentation/Profiles/PresentationProfile.cs
@@ -21,6 +21,5 @@ public class PresentationProfile : Profile
         CreateMap<UpdateUserAccountInfoRequest, UpdateUserAccountInfoCommand>();
         CreateMap<LoginRequest, LoginCommand>();
         CreateMap<DeleteMessageRequest, DeleteMessageCommand>();
-        CreateMap<CreateDiffieHellmanParameterRequest, CreateDiffieHellmanParameterCommand>();
     }
 }

--- a/MangoAPI.Presentation/Profiles/PresentationProfile.cs
+++ b/MangoAPI.Presentation/Profiles/PresentationProfile.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
 using MangoAPI.BusinessLogic.ApiCommands.Messages;
 using MangoAPI.BusinessLogic.ApiCommands.PasswordRestoreRequests;
 using MangoAPI.BusinessLogic.ApiCommands.Sessions;


### PR DESCRIPTION
Implement GET: api/key-exchange/openssl-key-exchange-requests/public-key/{requestId}, downloads a public key of the partner on key exchange request.