### PR TITLE
MANGO-406. Implement DELETE: api/api/key-exchange/openssl-key-exchange-requests/{requestId}, deletes a request by ID.

### DIFF
--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandHandler.cs
@@ -38,14 +38,6 @@ public class
             return _responseFactory.ConflictResponse(message, description);
         }
 
-        if (!request.Confirmed)
-        {
-            keyExchangeRequest.IsConfirmed = false;
-
-            await _mangoPostgresDbContext.SaveChangesAsync(cancellationToken);
-            return _responseFactory.SuccessResponse(ResponseBase.SuccessResponse);
-        }
-
         await using var target = new MemoryStream();
         await request.ReceiverPublicKey.CopyToAsync(target, cancellationToken);
 

--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandValidator.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslConfirmKeyExchangeCommandValidator.cs
@@ -8,7 +8,6 @@ public class OpenSslConfirmKeyExchangeCommandValidator : AbstractValidator<OpenS
     {
         RuleFor(x => x.UserId).NotEmpty();
         RuleFor(x => x.RequestId).NotEmpty();
-        RuleFor(x => x.Confirmed).Equal(true);
         RuleFor(x => x.ReceiverPublicKey).NotEmpty();
     }
 }

--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommand.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommand.cs
@@ -1,13 +1,11 @@
-﻿using System;
+using System;
 using MangoAPI.BusinessLogic.Responses;
 using MediatR;
-using Microsoft.AspNetCore.Http;
 
 namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
 
-public record OpenSslConfirmKeyExchangeCommand : IRequest<Result<ResponseBase>>
+public record OpenSslDeclineKeyExchangeCommand : IRequest<Result<ResponseBase>>
 {
     public Guid RequestId { get; init; }
     public Guid UserId { get; init; }
-    public IFormFile ReceiverPublicKey { get; init; }
 }

--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommandHandler.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommandHandler.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using MangoAPI.BusinessLogic.Responses;
+using MangoAPI.DataAccess.Database;
+using MangoAPI.Domain.Constants;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+
+public class
+    OpenSslDeclineKeyExchangeCommandHandler : IRequestHandler<OpenSslDeclineKeyExchangeCommand, Result<ResponseBase>>
+{
+    private readonly MangoPostgresDbContext _mangoPostgresDbContext;
+    private readonly ResponseFactory<ResponseBase> _responseFactory;
+
+    public OpenSslDeclineKeyExchangeCommandHandler(
+        MangoPostgresDbContext mangoPostgresDbContext,
+        ResponseFactory<ResponseBase> responseFactory)
+    {
+        _mangoPostgresDbContext = mangoPostgresDbContext;
+        _responseFactory = responseFactory;
+    }
+
+    public async Task<Result<ResponseBase>> Handle(OpenSslDeclineKeyExchangeCommand request,
+        CancellationToken cancellationToken)
+    {
+        var keyExchangeRequest =
+            await _mangoPostgresDbContext.OpenSslKeyExchangeRequests
+                .FirstOrDefaultAsync(
+                    predicate: x => x.Id == request.RequestId,
+                    cancellationToken: cancellationToken);
+
+        if (keyExchangeRequest == null)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeRequestNotFound;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        if (keyExchangeRequest.ReceiverId != request.UserId)
+        {
+            const string message = ResponseMessageCodes.KeyExchangeDoesNotBelongToUser;
+            var description = ResponseMessageCodes.ErrorDictionary[message];
+
+            return _responseFactory.ConflictResponse(message, description);
+        }
+
+        _mangoPostgresDbContext.OpenSslKeyExchangeRequests.Remove(keyExchangeRequest);
+
+        await _mangoPostgresDbContext.SaveChangesAsync(cancellationToken);
+
+        var result = ResponseBase.SuccessResponse;
+
+        return _responseFactory.SuccessResponse(result);
+    }
+}

--- a/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommandValidator.cs
+++ b/MangoAPI.BusinessLogic/ApiCommands/KeyExchange/OpenSslDeclineKeyExchangeCommandValidator.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation;
+
+namespace MangoAPI.BusinessLogic.ApiCommands.KeyExchange;
+
+public class OpenSslDeclineKeyExchangeCommandValidator : AbstractValidator<OpenSslDeclineKeyExchangeCommand>
+{
+    public OpenSslDeclineKeyExchangeCommandValidator()
+    {
+        RuleFor(x => x.RequestId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
+++ b/MangoAPI.Presentation/Controllers/KeyExchangeController.cs
@@ -83,7 +83,6 @@ public class KeyExchangeController : ApiControllerBase, IKeyExchangeController
     [HttpPut("openssl-key-exchange-requests/{requestId:guid}")]
     public async Task<IActionResult> OpenSslConfirmKeyExchangeRequest(
         [FromRoute] Guid requestId,
-        [FromQuery] bool confirmed,
         [FromForm] IFormFile receiverPublicKey,
         CancellationToken cancellationToken)
     {
@@ -93,11 +92,26 @@ public class KeyExchangeController : ApiControllerBase, IKeyExchangeController
         {
             RequestId = requestId,
             UserId = userId,
-            Confirmed = confirmed,
             ReceiverPublicKey = receiverPublicKey
         };
 
         return await RequestAsync(command, cancellationToken);
+    }
+
+    [HttpDelete("openssl-key-exchange-requests/{requestId:guid}")]
+    public async Task<IActionResult> OpenSslDeclineKeyExchangeRequest(
+        [FromRoute] Guid requestId,
+        CancellationToken cancellationToken)
+    {
+        var userId = HttpContext.User.GetUserId();
+
+        var request = new OpenSslDeclineKeyExchangeCommand
+        {
+            RequestId = requestId,
+            UserId = userId,
+        };
+
+        return await RequestAsync(request, cancellationToken);
     }
 
     [HttpGet("openssl-key-exchange-requests/public-keys/{requestId:guid}")]

--- a/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
+++ b/MangoAPI.Presentation/Interfaces/IKeyExchangeController.cs
@@ -20,9 +20,10 @@ public interface IKeyExchangeController
 
     public Task<IActionResult> OpenSslConfirmKeyExchangeRequest(
         Guid requestId,
-        bool confirmed,
         IFormFile receiverPublicKey,
         CancellationToken cancellationToken);
+
+    public Task<IActionResult> OpenSslDeclineKeyExchangeRequest(Guid requestId, CancellationToken cancellationToken);
 
     public Task<IActionResult> OpenSslDownloadPartnerPublicKey(Guid requestId,
         CancellationToken cancellationToken);


### PR DESCRIPTION
Implement DELETE: api/api/key-exchange/openssl-key-exchange-requests/{requestId}, deletes a request by ID.