### PR TITLE
MANGO-403. Implement CLI: openssl-create-key-exchange RECIEVER_ID, creates a request with a specified user by ID.

### DIFF
--- a/MangoAPI.DiffieHellmanConsole/Consts/Routes.cs
+++ b/MangoAPI.DiffieHellmanConsole/Consts/Routes.cs
@@ -4,8 +4,11 @@ public static class Routes
 {
     //private const string ApiDomain = "https://back.mangomessenger.company/api/";
     private const string ApiDomain = "https://localhost:5001/api/";
-    public const string ApiPublicKeysCngPublicKeys = ApiDomain + "public-keys/cng-public-keys";
     public const string SessionsRoute = ApiDomain + "sessions/";
-    public const string ApiKeyExchangeOpenSslParameters = ApiDomain + "key-exchange/openssl-parameters";
-    public const string ApiKeyExchangeCngKeyExchangeRequests = ApiDomain + "key-exchange/cng-key-exchange-requests";
+    
+    public const string CngPublicKeys = ApiDomain + "public-keys/cng-public-keys";
+    public const string CngKeyExchangeRequests = ApiDomain + "key-exchange/cng-key-exchange-requests";
+    
+    public const string OpenSslParameters = ApiDomain + "key-exchange/openssl-parameters";
+    public const string OpenSslKeyExchangeRequests = ApiDomain + "key-exchange/openssl-key-exchange-requests";
 }

--- a/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
+++ b/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
@@ -50,6 +50,7 @@ public static class InjectionExtensions
         collection.AddSingleton<OpenSslGetDhParametersHandler>();
         collection.AddSingleton<OpenSslGeneratePrivateKeyHandler>();
         collection.AddSingleton<OpenSslGeneratePublicKeyHandler>();
+        collection.AddSingleton<OpenSslCreateKeyExchangeHandler>();
 
         return collection;
     }

--- a/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateKeyExchangeHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslCreateKeyExchangeHandler.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+using MangoAPI.DiffieHellmanConsole.Services;
+
+namespace MangoAPI.DiffieHellmanConsole.OpenSslHandlers;
+
+public class OpenSslCreateKeyExchangeHandler
+{
+    private readonly KeyExchangeService _keyExchangeService;
+
+    public OpenSslCreateKeyExchangeHandler(KeyExchangeService keyExchangeService)
+    {
+        _keyExchangeService = keyExchangeService;
+    }
+
+    public async Task CreateKeyExchangeAsync(Guid receiverId)
+    {
+        Console.WriteLine("Creating key exchange request ...");
+        await _keyExchangeService.OpenSslCreateKeyExchangeAsync(receiverId);
+        Console.WriteLine($"Key exchange with {receiverId} has been created successfully.");
+    }
+}

--- a/MangoAPI.DiffieHellmanConsole/Program.cs
+++ b/MangoAPI.DiffieHellmanConsole/Program.cs
@@ -160,6 +160,26 @@ public static class Program
                 
                 break;
             }
+            case "openssl-create-key-exchange":
+            {
+                var handler = serviceProvider.GetService<OpenSslCreateKeyExchangeHandler>() ??
+                              throw new ArgumentException(
+                                  $"Handler is null. Register it in dependency injection. {nameof(OpenSslCreateKeyExchangeHandler)}");
+                
+                var receiverIdString = args[1];
+
+                var isParsed = Guid.TryParse(receiverIdString, out var receiverId);
+
+                if (!isParsed)
+                {
+                    Console.WriteLine("Invalid or empty receiver ID.");
+                    return;
+                }
+
+                await handler.CreateKeyExchangeAsync(receiverId);
+                
+                break;
+            }
             default:
             {
                 Console.WriteLine("Unrecognized command.");

--- a/MangoAPI.DiffieHellmanConsole/Services/PublicKeysService.cs
+++ b/MangoAPI.DiffieHellmanConsole/Services/PublicKeysService.cs
@@ -37,7 +37,7 @@ public class PublicKeysService
     {
         var result = await HttpRequest.GetAsync(
             client: _httpClient,
-            route: Routes.ApiPublicKeysCngPublicKeys);
+            route: Routes.CngPublicKeys);
 
         var response = JsonConvert.DeserializeObject<GetPublicKeysResponse>(result);
 


### PR DESCRIPTION
MANGO-403. Implement CLI: openssl-create-key-exchange RECIEVER_ID, creates a request with a specified user by ID.