### PR TITLE
MANGO-408. Implement CLI: openssl-print-key-exchanges, returns all the users key exchanges.

### DIFF
--- a/MangoAPI.BusinessLogic/Models/OpenSslKeyExchangeRequest.cs
+++ b/MangoAPI.BusinessLogic/Models/OpenSslKeyExchangeRequest.cs
@@ -9,6 +9,16 @@ public record OpenSslKeyExchangeRequest
     public Guid ReceiverId { get; init; }
     public bool IsConfirmed { get; init; }
     public Actor Actor { get; init; }
+
+    public override string ToString()
+    {
+        return
+            $"Request Id: {RequestId}, \n" +
+            $"Sender Id: {SenderId}, \n" +
+            $"Receiver Id: {ReceiverId}, \n" +
+            $"Confirmed: {IsConfirmed}, \n" +
+            $"Actor: {Actor.ToString()} \n";
+    }
 }
 
 public enum Actor

--- a/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
+++ b/MangoAPI.DiffieHellmanConsole/Extensions/InjectionExtensions.cs
@@ -51,6 +51,7 @@ public static class InjectionExtensions
         collection.AddSingleton<OpenSslGeneratePrivateKeyHandler>();
         collection.AddSingleton<OpenSslGeneratePublicKeyHandler>();
         collection.AddSingleton<OpenSslCreateKeyExchangeHandler>();
+        collection.AddSingleton<OpenSslPrintKeyExchangesHandler>();
 
         return collection;
     }

--- a/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslPrintKeyExchangesHandler.cs
+++ b/MangoAPI.DiffieHellmanConsole/OpenSslHandlers/OpenSslPrintKeyExchangesHandler.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using MangoAPI.DiffieHellmanConsole.Services;
+
+namespace MangoAPI.DiffieHellmanConsole.OpenSslHandlers;
+
+public class OpenSslPrintKeyExchangesHandler
+{
+    private readonly KeyExchangeService _keyExchangeService;
+
+    public OpenSslPrintKeyExchangesHandler(KeyExchangeService keyExchangeService)
+    {
+        _keyExchangeService = keyExchangeService;
+    }
+
+    public async Task PrintKeyExchangesAsync()
+    {
+        Console.WriteLine("Printing key-exchange requests ...");
+        var list = await _keyExchangeService.OpensslPrintKeyExchangesAsync();
+        list.ForEach(Console.WriteLine);
+        Console.WriteLine("Key exchanges has been printed successfully.");
+    }
+}

--- a/MangoAPI.DiffieHellmanConsole/Program.cs
+++ b/MangoAPI.DiffieHellmanConsole/Program.cs
@@ -180,6 +180,16 @@ public static class Program
                 
                 break;
             }
+            case "openssl-print-key-exchanges":
+            {
+                var handler = serviceProvider.GetService<OpenSslPrintKeyExchangesHandler>() ??
+                              throw new ArgumentException(
+                                  $"Handler is null. Register it in dependency injection. {nameof(OpenSslPrintKeyExchangesHandler)}");
+
+                await handler.PrintKeyExchangesAsync();
+                
+                break;
+            }
             default:
             {
                 Console.WriteLine("Unrecognized command.");


### PR DESCRIPTION
MANGO-408. Implement CLI: openssl-print-key-exchanges, returns all the users key exchanges.