### PR TITLE
MANGO-416. Implement CLI: openssl-print-key-exchange REQUEST_ID, prints a key exchange to the console.

### DIFF
--- a/MangoAPI.DiffieHellmanConsole/Program.cs
+++ b/MangoAPI.DiffieHellmanConsole/Program.cs
@@ -211,6 +211,23 @@ public static class Program
                 await handler.DeclineKeyExchangeAsync(requestId);
                 break;
             }
+            case "openssl-print-key-exchange":
+            {
+                var handler = DependencyResolver.ResolveService<OpenSslGetKeyExchangeByIdHandler>();
+
+                var requestIdString = args[1];
+
+                var isParsed = Guid.TryParse(requestIdString, out var requestId);
+
+                if (!isParsed)
+                {
+                    Console.WriteLine("Invalid or empty request ID.");
+                    return;
+                }
+
+                await handler.GetKeyExchangeByIdAsync(requestId);
+                break;
+            }
             default:
             {
                 Console.WriteLine("Unrecognized command.");

--- a/MangoAPI.DiffieHellmanLibrary/Extensions/OpenSslInjectionExtensions.cs
+++ b/MangoAPI.DiffieHellmanLibrary/Extensions/OpenSslInjectionExtensions.cs
@@ -21,6 +21,7 @@ public static class OpenSslInjectionExtensions
         collection.AddSingleton<OpenSslCreateCommonSecretHandler>();
         collection.AddSingleton<OpenSslDownloadPublicKeyHandler>();
         collection.AddSingleton<OpenSslDeclineKeyExchangeHandler>();
+        collection.AddSingleton<OpenSslGetKeyExchangeByIdHandler>();
 
         return collection;
     }

--- a/MangoAPI.DiffieHellmanLibrary/OpenSslHandlers/OpenSslGetKeyExchangeByIdHandler.cs
+++ b/MangoAPI.DiffieHellmanLibrary/OpenSslHandlers/OpenSslGetKeyExchangeByIdHandler.cs
@@ -1,0 +1,24 @@
+﻿using MangoAPI.DiffieHellmanLibrary.Services;
+
+namespace MangoAPI.DiffieHellmanLibrary.OpenSslHandlers;
+
+public class OpenSslGetKeyExchangeByIdHandler
+{
+    private readonly OpenSslKeyExchangeService _openSslKeyExchangeService;
+
+    public OpenSslGetKeyExchangeByIdHandler(OpenSslKeyExchangeService openSslKeyExchangeService)
+    {
+        _openSslKeyExchangeService = openSslKeyExchangeService;
+    }
+
+    public async Task GetKeyExchangeByIdAsync(Guid requestId)
+    {
+        Console.WriteLine($"Reading the key exchange {requestId} ...");
+
+        var exchangeRequest = await _openSslKeyExchangeService.OpenSslGetKeyExchangeByIdAsync(requestId);
+
+        Console.WriteLine(exchangeRequest);
+
+        Console.WriteLine("Reading completed.");
+    }
+}

--- a/MangoAPI.DiffieHellmanLibrary/Services/OpenSslKeyExchangeService.cs
+++ b/MangoAPI.DiffieHellmanLibrary/Services/OpenSslKeyExchangeService.cs
@@ -309,4 +309,23 @@ public class OpenSslKeyExchangeService
 
         return true;
     }
+
+    public async Task<OpenSslKeyExchangeRequest> OpenSslGetKeyExchangeByIdAsync(Guid requestId)
+    {
+        var address = $"{OpenSslRoutes.OpenSslKeyExchangeRequests}/{requestId}";
+        var uri = new Uri(address, UriKind.Absolute);
+
+        var response = await _httpClient.GetAsync(uri);
+        response.EnsureSuccessStatusCode();
+
+        var jsonAsString = await response.Content.ReadAsStringAsync();
+
+        var deserializeObject =
+            JsonConvert.DeserializeObject<OpenSslGetKeyExchangeRequestByIdResponse>(jsonAsString)
+            ?? throw new InvalidOperationException();
+
+        var result = deserializeObject.KeyExchangeRequest;
+
+        return result;
+    }
 }


### PR DESCRIPTION
MANGO-416. Implement CLI: openssl-print-key-exchange REQUEST_ID, prints a key exchange to the console.