### PR TITLE
MANGO-468. Implement GET: /api​/cng-key-exchange-requests/{requestId}, returns cng key exchange request by ID. Use it in CngConfirmKeyExchangeRequestHandler.cs

### DIFF
--- a/MangoAPI.DiffieHellmanLibrary/CngHandlers/CngConfirmKeyExchangeRequestHandler.cs
+++ b/MangoAPI.DiffieHellmanLibrary/CngHandlers/CngConfirmKeyExchangeRequestHandler.cs
@@ -30,7 +30,6 @@ public class CngConfirmKeyExchangeRequestHandler
 
         var requestId = Guid.Parse(args[1]);
         
-        // TODO: create separate REST handler get request by ID
         var getKeyExchangeResponse = await _cngKeyExchangeService.CngGetKeyExchangeById(requestId);
         var exchangeRequest = getKeyExchangeResponse.KeyExchangeRequest;
 

--- a/MangoAPI.DiffieHellmanLibrary/CngHandlers/CngConfirmKeyExchangeRequestHandler.cs
+++ b/MangoAPI.DiffieHellmanLibrary/CngHandlers/CngConfirmKeyExchangeRequestHandler.cs
@@ -29,20 +29,10 @@ public class CngConfirmKeyExchangeRequestHandler
         var tokens = tokensResponse.Tokens;
 
         var requestId = Guid.Parse(args[1]);
-
-        var getKeyExchangeResponse = await _cngKeyExchangeService.CngGetKeyExchangesAsync();
-
+        
         // TODO: create separate REST handler get request by ID
-        var exchangeRequest = getKeyExchangeResponse.KeyExchangeRequests
-            .FirstOrDefault(x => x.RequestId == requestId);
-
-        if (exchangeRequest == null)
-        {
-            const string error = ResponseMessageCodes.KeyExchangeRequestNotFound;
-            var details = ResponseMessageCodes.ErrorDictionary[error];
-            Console.WriteLine($@"{error}. {details}");
-            return;
-        }
+        var getKeyExchangeResponse = await _cngKeyExchangeService.CngGetKeyExchangeById(requestId);
+        var exchangeRequest = getKeyExchangeResponse.KeyExchangeRequest;
 
         var ecDiffieHellmanCng = _cngEcdhService.CngGenerateEcdhKeysPair(
             out var privateKeyBase64String,

--- a/MangoAPI.DiffieHellmanLibrary/Services/CngKeyExchangeService.cs
+++ b/MangoAPI.DiffieHellmanLibrary/Services/CngKeyExchangeService.cs
@@ -43,6 +43,17 @@ public class CngKeyExchangeService
         return response ?? throw new InvalidOperationException();
     }
 
+    public async Task<CngGetKeyExchangeRequestByIdResponse> CngGetKeyExchangeById(Guid requestId)
+    {
+        var result = await HttpRequestHelper.GetAsync(
+            client: _httpClient,
+            route: $"{CngRoutes.CngKeyExchangeRequests}/{requestId}");
+
+        var response = JsonConvert.DeserializeObject<CngGetKeyExchangeRequestByIdResponse>(result);
+        
+        return response ?? throw new InvalidOperationException();
+    }
+
     public async Task<CngCreateKeyExchangeResponse> CngCreateKeyExchangeRequestAsync(
         Guid requestUserId,
         string publicKey)


### PR DESCRIPTION
MANGO-468. Implement GET: /api​/cng-key-exchange-requests/{requestId}, returns cng key exchange request by ID. Use it in CngConfirmKeyExchangeRequestHandler.cs