### PR TITLE
MANGO-499. Make azure devops pipelines run on the ubuntu-latest

### DIFF
--- a/build/azure-pipelines-deploy.yml
+++ b/build/azure-pipelines-deploy.yml
@@ -24,20 +24,20 @@ stages:
       - job: "Build"
         displayName: 'Build and Test'
         pool:
-          vmImage: 'ubuntu-20.04'
-        
+          vmImage: 'ubuntu-latest'
+
         steps:
           - template: azure-pipelines-common.yml
 
   - stage: "dev"
-    displayName: "Deploy Mango Web API to Dev Environment"
+    displayName: "Deploy Mango Messenger to DEV Environment"
     dependsOn: Build_Test
     condition: succeeded('Build_Test')
     jobs:
       - deployment: Deploy_Mango_Web_API_to_Dev
-        displayName: "Deploy Mango Web API to Dev Environment"
+        displayName: "Deploy Mango Messenger to DEV Environment"
         pool:
-          vmImage: "ubuntu 20.04"
+          vmImage: "ubuntu-latest"
         environment: dev
         variables:
           - group: MANGO_DEV_ENV_VARS

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
       - job: "Build"
         displayName: 'Build and Test'
         pool:
-          vmImage: 'ubuntu-20.04'
-        
+          vmImage: 'ubuntu-latest'
+
         steps:
           - template: azure-pipelines-common.yml


### PR DESCRIPTION
MANGO-499. Make azure devops pipelines run on the ubuntu-latest